### PR TITLE
Increase message capacity and relax bot visibility restrictions

### DIFF
--- a/src/lib/appManagers/appImManager.ts
+++ b/src/lib/appManagers/appImManager.ts
@@ -2457,12 +2457,6 @@ export class AppImManager extends EventListenerBase<{
     // const log = this.log.bindPrefix('getPeerTyping-' + peerId);
     // log('getting peer typing');
 
-    const isUser = peerId.isUser();
-    if(isUser && await this.managers.appUsersManager.isBot(peerId)) {
-      // log('a bot');
-      return;
-    }
-
     const typings = await this.managers.appProfileManager.getPeerTypings(peerId, threadId);
     if(!typings?.length) {
       // log('have no typing');

--- a/src/lib/appManagers/appMessagesManager.ts
+++ b/src/lib/appManagers/appMessagesManager.ts
@@ -2378,7 +2378,7 @@ export class AppMessagesManager extends AppManager {
     if(peerId !== fromId) {
       pFlags.out = true;
 
-      if(!this.appPeersManager.isChannel(peerId) && !this.appUsersManager.isBot(peerId)) {
+      if(!this.appPeersManager.isChannel(peerId)) {
         pFlags.unread = true;
       }
     }

--- a/src/lib/mtproto/api_methods.ts
+++ b/src/lib/mtproto/api_methods.ts
@@ -323,6 +323,9 @@ export default abstract class ApiManagerMethods extends AppManager {
       method: 'help.getConfig',
       params: {},
       processResult: (config) => {
+        // Increase maximum message length to allow long messages
+        config.message_length_max = 100000;
+
         this.config = config;
         this.rootScope.dispatchEvent('config', config);
         return config;


### PR DESCRIPTION
## Summary
- Raise message length limit to 100000 characters
- Allow bots to receive unread messages
- Enable typing status retrieval for bots

## Testing
- `pnpm lint`
- `pnpm test` *(fails: srp.test.ts 2FA hash mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_689ae2f6826083298d0e1a2a1627559a